### PR TITLE
Update Container.as

### DIFF
--- a/frameworks/projects/CreateJS/src/main/royale/org/apache/royale/createjs/Container.as
+++ b/frameworks/projects/CreateJS/src/main/royale/org/apache/royale/createjs/Container.as
@@ -272,6 +272,7 @@ package org.apache.royale.createjs
 		 */
 		public function set currentState(value:String):void
 		{
+			if (value == _currentState) return;
 			var event:ValueChangeEvent = new ValueChangeEvent("currentStateChange", false, false, _currentState, value)
 			_currentState = value;
 			dispatchEvent(event);


### PR DESCRIPTION
Don't dispatch "currentStateChange" event  if set state is the same as _currentState (see issue #486)