### PR TITLE
Update View.as

### DIFF
--- a/frameworks/projects/CreateJS/src/main/royale/org/apache/royale/createjs/core/View.as
+++ b/frameworks/projects/CreateJS/src/main/royale/org/apache/royale/createjs/core/View.as
@@ -301,6 +301,7 @@ package org.apache.royale.createjs.core
 		 */
 		public function set currentState(value:String):void
 		{
+			if (value == _currentState) return;
 			var event:ValueChangeEvent = new ValueChangeEvent("currentStateChange", false, false, _currentState, value)
 			_currentState = value;
 			dispatchEvent(event);


### PR DESCRIPTION
Don't dispatch "currentStateChange" event  if set state is the same as _currentState (see issue #486)