### PR TITLE
Update UIComponent.as

### DIFF
--- a/frameworks/projects/MXRoyale/src/main/royale/mx/core/UIComponent.as
+++ b/frameworks/projects/MXRoyale/src/main/royale/mx/core/UIComponent.as
@@ -3051,6 +3051,7 @@ COMPILE::JS
      */
     public function set currentState(value:String):void
     {
+    	if (value == _currentState) return;
         var event:ValueChangeEvent = new ValueChangeEvent("currentStateChange", false, false, _currentState, value)
         _currentState = value;
         addEventListener("stateChangeComplete", stateChangeCompleteHandler);


### PR DESCRIPTION
Don't dispatch "currentStateChange" event  if set state is the same as _currentState (see issue #486)